### PR TITLE
Add memcached slab_page_size param support on template and image

### DIFF
--- a/images/miq-memcached/container-entrypoint
+++ b/images/miq-memcached/container-entrypoint
@@ -10,5 +10,9 @@ if [ -n "${MEMCACHED_MAX_CONNECTIONS}" ]; then
     OPTIONS+=" -c $MEMCACHED_MAX_CONNECTIONS"
 fi
 
+if [ -n "${MEMCACHED_SLAB_PAGE_SIZE}" ]; then
+    OPTIONS+=" -I $MEMCACHED_SLAB_PAGE_SIZE"
+fi
+
 set -eu
 exec "$@" $OPTIONS

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -208,6 +208,9 @@ objects:
               -
                 name: "MEMCACHED_MAX_CONNECTIONS"
                 value: "${MEMCACHED_MAX_CONNECTIONS}"
+              -
+                name: "MEMCACHED_SLAB_PAGE_SIZE"
+                value: "${MEMCACHED_SLAB_PAGE_SIZE}"
             resources:
               limits:
                 memory: "${MEMORY_MEMCACHED_LIMIT}"
@@ -359,6 +362,10 @@ parameters:
     name: "MEMCACHED_MAX_CONNECTIONS"
     displayName: "Maximum number of connections for memcached"
     value: "1024"
+  -
+    name: "MEMCACHED_SLAB_PAGE_SIZE"
+    displayName: "Size of each slab page for memcached in bytes, supports m or k"
+    value: "1m"
   -
     name: "POSTGRESQL_MAX_CONNECTIONS"
     displayName: "Maximum Database Connections"


### PR DESCRIPTION
@bazulay @bdunne

This will allow the user to deploy the memcached pod with customized slab_page_size parameter, as promised in #10075 for OpenShift builds :smiley: 