### PR TITLE
Change Deployment Strategy for miq-app to Recreate

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -129,7 +129,7 @@ objects:
             kind: "ImageStreamTag"
             name: "miq-app:latest"
     strategy:
-      type: Rolling
+      type: "Recreate"
 - apiVersion: v1
   kind: "Service"
   metadata:


### PR DESCRIPTION
- Rolling has issues with database concurrency when upgrading a miq-app deployment, switching back to recreate