### PR TITLE
add app pv instructions and yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ _**As admin:**_
 
 ```bash
 $ oc create -f miq-pv-example.yaml
+$ oc create -f miq-pv-app-example.yaml
 ```
 Verify pv creation
 ```bash
 $ oc get pv
 NAME       CAPACITY   ACCESSMODES   STATUS      CLAIM     REASON    AGE
+manageiq   2Gi        RWO           Available                       24d
 nfs-pv01   2Gi        RWO           Available                       24d
 ```
 ## Deploy MIQ

--- a/miq-pv-app-example.yaml
+++ b/miq-pv-app-example.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: manageiq
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs: 
+    path: /opt/nfs/volumes-app
+    server: 10.19.0.216
+  persistentVolumeReclaimPolicy: Recycle


### PR DESCRIPTION
The manageiq template [requires an application volume](https://github.com/fbladilo/miq-on-openshift/blob/master/templates/miq-template.yaml#L60-L69) in addition to the postgres volume but does not include the creation of the volume in the instructions.

This adds a volume for manageiq to use and updates the README