### PR TITLE
Fix versions for miq-postgresql and miq-memcached on template

### DIFF
--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -193,7 +193,7 @@ objects:
             - "memcached"
           from:
             kind: "ImageStreamTag"
-            name: "miq-memcached:latest"
+            name: "miq-memcached:1.4.15"
       -
         type: "ConfigChange"
     replicas: 1
@@ -297,7 +297,7 @@ objects:
         containers:
           -
             name: "postgresql"
-            image: "fbladilo/miq-postgresql:latest"
+            image: "fbladilo/miq-postgresql:9.5"
             ports:
               -
                 containerPort: 5432

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -172,7 +172,7 @@ objects:
   metadata:
     name: miq-memcached
     annotations:
-      description: "Keeps track of changes in the memcached image"
+      description: "Keeps track of changes in the ManageIQ memcached image"
   spec:
     dockerImageRepository: docker.io/fbladilo/miq-memcached
 - apiVersion: v1
@@ -209,7 +209,7 @@ objects:
         containers:
           -
             name: "memcached"
-            image: "fbladilo/miq-memcached:latest"
+            image: "fbladilo/miq-memcached:1.4.15"
             ports:
               -
                 containerPort: 11211
@@ -277,7 +277,7 @@ objects:
             - "postgresql"
           from:
             kind: "ImageStreamTag"
-            name: "miq-postgresql:latest"
+            name: "miq-postgresql:9.5"
       -
         type: "ConfigChange"
     replicas: 1


### PR DESCRIPTION
- Prevent service pods from using latest tag on deployments, it is safer this way
- The miq-app deployment image will continue to use latest tag since we can only build master