### PR TITLE
Re-work run_hook function to accept a script name argument

### DIFF
--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -22,10 +22,12 @@ case "${DEPLOYMENT_STATUS}" in
   upgrade)
   echo "== Starting Upgrade =="
   backup_pv_data
+  run_hook pre-upgrade
   restore_pv_data
   pre_upgrade_hook
   setup_memcached
   migrate_db
+  run_hook post-upgrade
   ;;
   new_deployment)
   echo "== Starting New Deployment =="


### PR DESCRIPTION
- run_hook now accepts a script name argument, it is meant to be executed at any stage of the deployment
- two default entries were added for the upgrade procedure pre-upgrade and post-upgrade
- if a script is not found, run_hook returns 1 and the deployment continues
- if a script is found but exits abnormally, the deployment fails and exit 1