### PR TITLE
Add APPLICATION_INIT_DELAY as a template parameter and minor fixes

### DIFF
--- a/images/miq-app/docker-assets/appliance-initialize.service
+++ b/images/miq-app/docker-assets/appliance-initialize.service
@@ -6,7 +6,6 @@ Before=evmserverd.service
 TimeoutStartSec=5m
 Type=oneshot
 EnvironmentFile=/container.env.vars
-ExecStartPre=/usr/bin/sleep 30
 ExecStart=/bin/appliance-initialize.sh
 ExecStartPost=/usr/bin/systemctl disable appliance-initialize
 ExecStopPost=-/bin/sh -c '${CONTAINER_SCRIPTS_ROOT}/appliance-stop-post.sh'

--- a/images/miq-app/docker-assets/appliance-initialize.sh
+++ b/images/miq-app/docker-assets/appliance-initialize.sh
@@ -5,6 +5,9 @@
 # Source OpenShift scripting env
 [[ -s ${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh ]] && source ${CONTAINER_SCRIPTS_ROOT}/container-deploy-common.sh
 
+# Delay in seconds before we init, allows rest of services to settle
+sleep ${APPLICATION_INIT_DELAY}
+
 # Prepare initialization environment
 prepare_init_env
 
@@ -24,7 +27,6 @@ case "${DEPLOYMENT_STATUS}" in
   backup_pv_data
   run_hook pre-upgrade
   restore_pv_data
-  pre_upgrade_hook
   setup_memcached
   migrate_db
   run_hook post-upgrade

--- a/templates/miq-template.yaml
+++ b/templates/miq-template.yaml
@@ -115,6 +115,9 @@ objects:
                 mountPath: "/persistent"
           env:
             -
+              name: "APPLICATION_INIT_DELAY"
+              value: "${APPLICATION_INIT_DELAY}"
+            -
               name: "DATABASE_SERVICE_NAME"
               value: "${DATABASE_SERVICE_NAME}"
             -
@@ -424,6 +427,12 @@ parameters:
     displayName: "Application Hostname"
     description: "The exposed hostname that will route to the application service, if left blank a value will be defaulted."
     value: ""
+  -
+    name: "APPLICATION_INIT_DELAY"
+    displayName: "Application Init Delay"
+    required: true
+    description: "Delay in seconds before we attempt to initialize the application."
+    value: "30"
   -
     name: "APPLICATION_VOLUME_CAPACITY"
     displayName: "Application Volume Capacity"


### PR DESCRIPTION
- Default APPLICATION_INIT_DELAY parameter is 30 seconds to allow rest of services to settle
- /bin/appliance-initialize.sh now calls sleep instead of appliance-initialize systemd service unit file
- Removed pre_upgrade_hook call from /bin/appliance-initialize.sh (function no longer valid)